### PR TITLE
Update bans.json

### DIFF
--- a/docs/bans.json
+++ b/docs/bans.json
@@ -1,12 +1,23 @@
 {
     "repositories": [
-        "In-AppStore.com Cydia Repository",
+        "apt.abcydia.com",
+        "apt.feng.com",
+        "cydia00.net",
+        "cydia.heaveniphone.com",
+        "cydia.ilove-apple.com",
+        "cydia.iphonecake.com",
+        "cydia.kiiimo.org",
+        "cydia.vn",
+        "mohadu31.com",
+        "rejail.ru",
+        "repo.appleyardim.org",
+        "repo.biteyourapple.net",
+        "repo.hackyouriphone.org",
+        "repo.kurdios.com",
+        "repo.thedeadlyapple.com",
         "repo.xarold.com",
-        "AppCake",
-        "Xarold Repository",
-        "HackYouriPhone",
-        "Whited00r 7.1 OTA",
-        "BiteYourApple",
-        "repo.biteyourapple.net"
+        "sinfuliphonerepo.com",
+        "system.in-appstore.com",
+        "Whited00r 7.1 OTA"
     ]
 }


### PR DESCRIPTION
Updated bans.json with some pirates repo. Why repo.xarold.com is listed into repository-urls.json too?