### PR TITLE
Update devices.json (fix incorrect deviceID for iPhone Xs Max)

### DIFF
--- a/docs/devices.json
+++ b/docs/devices.json
@@ -227,7 +227,7 @@
         },
         {
             "arch32bit": false,
-            "deviceId": "iPhone11,5",
+            "deviceId": "iPhone11,6",
             "deviceName": "iPhone Xs Max"
         },
         {


### PR DESCRIPTION
deviceID for iPhone Xs Max is "iPhone11,6", not "iPhone11,5". I'm here fixing this because my contributions have been showing up as "Unknown device". One reference (of many): https://everymac.com/ultimate-mac-lookup/?search_keywords=iPhone11,6

It's particularly important for A12 device owners to know the specific *model* because a lot of tweaks, even relatively new ones (less than a year old) may run on same iOS (i.e. 12.1.1) but not on A12 device, unless they've been specifically compiled or re-compiled to do so. So modelID is critical compatibility info for anyone with an A12 device.